### PR TITLE
add array ability to imageBackgroundBorderWidth

### DIFF
--- a/src/cropit.coffee
+++ b/src/cropit.coffee
@@ -219,7 +219,7 @@ class Cropit
     if @options.imageBackground
       @$imageBg.css
         left: @offset.x + @imgBgBorder[3]
-        top: @offset.y + @imgBgBorder[]
+        top: @offset.y + @imgBgBorder[0]
 
   fixOffset: (offset) ->
     return offset unless @imageLoaded


### PR DESCRIPTION
Use cases for extra border on 1-2 sides:
- on top for image title
- on bottom for caption
- on one side for menu
- both sides for arrows (previous/advance, eg slider)

Usage:
backwards compatible (if only single value, will coerce into array of same values)
`imageBackgroundBorderWidth` may accept array with the values [top, right, bottom, left](order mirrors CSS)

Technical:
I don't know CoffeeScript & it is 4am so please forgive me for mistakes ;^)
Built first hacking JS directly & works; let me know if you want to see that file to compare.
swapped variable from `@options.imageBackgroundBorderWidth` to `@imgBgBorder[]`
