### PR TITLE
Add "main" section to package.json for CommonJS usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cropit",
-  "main": "dist/jquery.cropit.min.js",
+  "main": "dist/jquery.cropit.js",
   "description": "Customizable crop and zoom.",
   "version": "0.1.9",
   "author": {


### PR DESCRIPTION
Hi,

I'm currently using cropit for a React project, in which I am using Browserify to manage my dependencies. We have discovered that we can make cropit work with our project by adding this line to the package.json file. Thus, we were hoping you would merge this into master so others could take advantage of this.
