### PR TITLE
Fixing rejectSmallImage + minZoom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+bower_components

--- a/dist/jquery.cropit.js
+++ b/dist/jquery.cropit.js
@@ -822,7 +822,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        this.minZoom = Math.max(widthRatio, heightRatio);
 	      }
 
-	      if (!rejectSmallImage) {
+	      if (!rejectSmallImage && minZoom !== 'fill') {
 	        this.minZoom = Math.min(this.minZoom, 1);
 	      }
 

--- a/src/zoomer.js
+++ b/src/zoomer.js
@@ -14,7 +14,7 @@ class Zoomer {
       this.minZoom = Math.max(widthRatio, heightRatio);
     }
 
-    if (!rejectSmallImage) {
+    if (!rejectSmallImage && minZoom !== 'fill') {
       this.minZoom = Math.min(this.minZoom, 1);
     }
 


### PR DESCRIPTION
Issue was that if rejectSmallImage was set to false (allowing a small image) and minZoom was set to 'fill' (meaning the user intended the image to fill the preview), the 'fill' option was being ignored.