### PR TITLE
onFileChange event as param

### DIFF
--- a/dist/jquery.cropit.js
+++ b/dist/jquery.cropit.js
@@ -341,8 +341,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  }, {
 	    key: 'onFileChange',
-	    value: function onFileChange() {
-	      this.options.onFileChange();
+	    value: function onFileChange(e) {
+	      this.options.onFileChange(e);
 
 	      if (this.$fileInput.get(0).files) {
 	        this.loadFileReader(this.$fileInput.get(0).files[0]);


### PR DESCRIPTION
Passing event as parameter on onFileChange callback, allows me retrieve more data from input file as name, type and size. It makes the export process more dynamic.

Reference about event: http://www.andygup.net/easily-find-image-type-in-javascript/