### PR TITLE
Global jQuery, Chrome speed improvement, and bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     ]
   },
   "dependencies": {
-    "jquery": ">=1.9"
+    "jquery": ">=1.9",
+    "jquery-migrate": "^3.0.0"
   },
   "devDependencies": {
     "babel-core": "~5.5.8",

--- a/src/cropit.js
+++ b/src/cropit.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 
-import Zoomer from './Zoomer';
+import Zoomer from './zoomer';
 import { CLASS_NAMES, ERRORS, EVENTS } from './constants';
 import { loadDefaults } from './options';
 import { exists, round } from './utils';

--- a/src/cropit.js
+++ b/src/cropit.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import Zoomer from './zoomer';
 import { CLASS_NAMES, ERRORS, EVENTS } from './constants';
 import { loadDefaults } from './options';

--- a/src/cropit.js
+++ b/src/cropit.js
@@ -25,7 +25,7 @@ class Cropit {
     };
 
     this.$preview = this.options.$preview.css('position', 'relative');
-    this.$fileInput = this.options.$fileInput.attr({ accept: 'image/*' });
+    this.$fileInput = this.options.$fileInput.attr({ accept: 'image/gif,image/jpeg,image/jpg,image/png,image/svg' });
     this.$zoomSlider = this.options.$zoomSlider.attr({ min: 0, max: 1, step: 0.01 });
 
     this.previewSize = {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,3 +1,4 @@
+import 'jquery-migrate';
 import Cropit from './cropit';
 import { PLUGIN_KEY } from './constants';
 import { exists } from './utils';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import Cropit from './cropit';
 import { PLUGIN_KEY } from './constants';
 import { exists } from './utils';


### PR DESCRIPTION
This PR fixes a few issues I've been wrestling with:

1. Assume the global presence of `jQuery`. When including cropit in another lib, the `require('jquery')` was loading a separate jQuery module instead of using the global one. I changed the code to just not require jQuery at all and assume it's in the global namespace. Thoughts?
2. Included `jquery-migrate` support for jQuery 3.x
2. `require('./Zoomer)` capitalization fix.
3. Chrome dialog fix (same as #214)